### PR TITLE
Store AbPanel env and condition variables in the current thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 script: 'bundle exec rspec spec'
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1.5

--- a/ab_panel.gemspec
+++ b/ab_panel.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakeweb"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "debugger"
+  spec.add_development_dependency "byebug"
 
   spec.add_runtime_dependency "mixpanel"
 end

--- a/lib/ab_panel.rb
+++ b/lib/ab_panel.rb
@@ -19,7 +19,7 @@ module AbPanel
     end
 
     def conditions
-      @conditions ||= assign_conditions!
+      Thread.current[:ab_panel_conditions] ||= assign_conditions!
     end
 
     # Set the experiment's conditions.
@@ -28,7 +28,7 @@ module AbPanel
     # the session.
     def conditions=(custom_conditions)
       return conditions unless custom_conditions
-      @conditions = assign_conditions! custom_conditions
+      Thread.current[:ab_panel_conditions] = assign_conditions! custom_conditions
     end
 
     def experiments
@@ -44,18 +44,18 @@ module AbPanel
     end
 
     def properties
-      @env[:properties]
+      env[:properties]
     end
 
     def env
-      @env ||= {
+      Thread.current[:ab_panel_env] ||= {
         'conditions' => conditions
       }
     end
 
     def reset!
-      @env = nil
-      @conditions = nil
+      Thread.current[:ab_panel_env] = nil
+      Thread.current[:ab_panel_conditions] = nil
     end
 
     def set_env(key, value)
@@ -67,7 +67,7 @@ module AbPanel
     end
 
     def funnels=(funnels)
-      env['funnels'] = funnels
+      Thread.current['ab_panel_env']['funnels'] = funnels
     end
 
     def add_funnel(funnel)

--- a/spec/ab_panel_spec.rb
+++ b/spec/ab_panel_spec.rb
@@ -88,4 +88,12 @@ describe AbPanel do
       AbPanel.funnels.to_a.should == funnels.to_a
     end
   end
+
+  describe 'thread-safety' do
+    it 'should set be safe' do
+      AbPanel.set_env(:test, 'a')
+      Thread.new { AbPanel.set_env(:test, 'b') }.join
+      expect(AbPanel.env[:test]).to eq 'a'
+    end
+  end
 end


### PR DESCRIPTION
This should fix the race conditions that where occurring using a multi threaded Rack server like Puma.