### PR TITLE
Fix bug where funnel could not be set because hash doesn't exist

### DIFF
--- a/lib/ab_panel.rb
+++ b/lib/ab_panel.rb
@@ -63,11 +63,11 @@ module AbPanel
     end
 
     def funnels
-      env['funnels'] ||= Set.new
+      env[:funnels] ||= Set.new
     end
 
     def funnels=(funnels)
-      Thread.current['ab_panel_env']['funnels'] = funnels
+      env[:funnels] = funnels
     end
 
     def add_funnel(funnel)

--- a/spec/ab_panel_spec.rb
+++ b/spec/ab_panel_spec.rb
@@ -62,6 +62,10 @@ describe AbPanel do
   end
 
   describe ".funnels" do
+    before do
+      AbPanel.reset!
+    end
+
     after do
       AbPanel.funnels = nil
     end


### PR DESCRIPTION
See title. The controller_additions wasn't able to set the funnel.