### PR TITLE
Cast AbPanel.funnels to set

### DIFF
--- a/lib/ab_panel/controller_additions.rb
+++ b/lib/ab_panel/controller_additions.rb
@@ -50,7 +50,7 @@ module AbPanel
       AbPanel.reset!
       AbPanel.conditions = cookies.signed['ab_panel_conditions']
       cookies.signed['ab_panel_conditions'] = AbPanel.conditions
-      AbPanel.funnels = cookies.signed['ab_panel_funnels']
+      AbPanel.funnels = Set.new(cookies.signed['ab_panel_funnels'])
       cookies.signed['ab_panel_funnels'] = AbPanel.funnels
 
       {


### PR DESCRIPTION
Without this cast it breaks on Rails 4 because the cookie is returned as an Array and not as a Set.