### PR TITLE
Serialize ab_panel_conditions cookie using JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 script: 'bundle exec rspec spec'
 rvm:
-  - 2.1.5
+  - 2.1.7

--- a/ab_panel.gemspec
+++ b/ab_panel.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = AbPanel::VERSION
   spec.authors       = ["Wouter de Vos", "Mark Mulder", "Peter de Ruijter"]
   spec.email         = ["wouter@springest.com", "markmulder@gmail.com", "hello@thisiswho.im"]
-  spec.description   = %q{Run A/B test experiments on your Rails 3+ site using Mixpanel as a backend.}
-  spec.summary       = %q{Run A/B test experiments on your Rails 3+ site using Mixpanel as a backend.}
+  spec.description   = %q{Run A/B test experiments on your Rails 4+ site using Mixpanel as a backend.}
+  spec.summary       = %q{Run A/B test experiments on your Rails 4+ site using Mixpanel as a backend.}
   spec.homepage      = "https://github.com/Springest/ab_panel"
   spec.license       = "MIT"
 
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rails", '~> 3.2'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakeweb"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
 
+  spec.add_runtime_dependency "rails", '~> 4.0'
   spec.add_runtime_dependency "mixpanel"
 end

--- a/lib/ab_panel.rb
+++ b/lib/ab_panel.rb
@@ -22,6 +22,16 @@ module AbPanel
       Thread.current[:ab_panel_conditions] ||= assign_conditions!
     end
 
+    def serialized_conditions
+      cs = {}
+
+      conditions.each_pair do |key, value|
+        cs[key] = value.marshal_dump
+      end
+
+      cs.to_json
+    end
+
     # Set the experiment's conditions.
     #
     # This is used to persist conditions from
@@ -78,6 +88,14 @@ module AbPanel
 
     def assign_conditions!(already_assigned=nil)
       cs = {}
+
+      if already_assigned
+        already_assigned.each do |key, value|
+          already_assigned[key] = OpenStruct.new(already_assigned[key])
+        end
+      end
+
+      already_assigned = OpenStruct.new already_assigned
 
       experiments.each do |experiment|
         cs[experiment] ||= {}

--- a/lib/ab_panel/controller_additions.rb
+++ b/lib/ab_panel/controller_additions.rb
@@ -48,10 +48,12 @@ module AbPanel
     # in the user's session.
     def initialize_ab_panel!(options = {})
       AbPanel.reset!
-      AbPanel.conditions = cookies.signed['ab_panel_conditions']
-      cookies.signed['ab_panel_conditions'] = AbPanel.conditions
-      AbPanel.funnels = Set.new(cookies.signed['ab_panel_funnels'])
-      cookies.signed['ab_panel_funnels'] = AbPanel.funnels
+
+      AbPanel.conditions = JSON.parse(cookies.signed[:ab_panel_conditions])
+
+      cookies.signed[:ab_panel_conditions] = AbPanel.serialized_conditions
+      AbPanel.funnels = Set.new(cookies.signed[:ab_panel_funnels])
+      cookies.signed[:ab_panel_funnels] = AbPanel.funnels
 
       {
         'distinct_id' => distinct_id,

--- a/spec/ab_panel/config_spec.rb
+++ b/spec/ab_panel/config_spec.rb
@@ -4,32 +4,32 @@ describe AbPanel::Config do
   let(:config) { AbPanel::Config.new }
   context "config" do
     before do
-      AbPanel::Config.any_instance.stub(:settings) { { exp1: { scenario1: 25, scenario2: 75 } } }
+      allow_any_instance_of(AbPanel::Config).to receive(:settings) { { exp1: { scenario1: 25, scenario2: 75 } } }
     end
 
     describe '.experiments' do
       subject { config.experiments }
-      it { should =~ [:exp1] }
+      it { is_expected.to match_array [:exp1] }
     end
 
     describe '.weights' do
       subject { config.weights('exp1') }
 
-      it { should =~ [75.0, 25.0] }
+      it { is_expected.to match_array [75.0, 25.0] }
     end
   end
   context "empty config" do
     before do
-      YAML.stub(:load) { false }
+      allow(YAML).to receive(:load) { false }
     end
     describe ".settings" do
       subject { config.settings }
-      it { should eq nil }
+      it { is_expected.to eq nil }
     end
 
     describe ".experiments" do
       subject { config.experiments }
-      it { should == {} }
+      it { is_expected.to eq({}) }
     end
   end
 end

--- a/spec/ab_panel/controller_additions_spec.rb
+++ b/spec/ab_panel/controller_additions_spec.rb
@@ -13,9 +13,9 @@ describe AbPanel::ControllerAdditions do
 
   describe "#distinct_id" do
     let(:cookies) { {} }
-    before { controller.stub_chain(:cookies, :signed).and_return(cookies) }
+    before { expect(controller).to receive_message_chain(:cookies, :signed).and_return(cookies) }
     subject { controller.distinct_id }
 
-    it { should match /^([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])$/ }
+    it { is_expected.to match /^([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])$/ }
   end
 end

--- a/spec/ab_panel/javascript_spec.rb
+++ b/spec/ab_panel/javascript_spec.rb
@@ -5,12 +5,12 @@ describe AbPanel::Javascript do
     AbPanel.set_env('distinct_id', 'distinct_id')
     AbPanel.set_env(:properties, { post_name: 'test' })
     result = JSON.parse(AbPanel::Javascript.environment)
-    result['distinct_id'].should == 'distinct_id'
+    expect(result['distinct_id']).to eq 'distinct_id'
   end
 
   it 'works without extra properties' do
     AbPanel.set_env(:properties, nil)
     result = JSON.parse(AbPanel::Javascript.environment)
-    result['distinct_id'].should == 'distinct_id'
+    expect(result['distinct_id']).to eq 'distinct_id'
   end
 end

--- a/spec/ab_panel_spec.rb
+++ b/spec/ab_panel_spec.rb
@@ -4,14 +4,14 @@ describe AbPanel do
   describe ".experiments" do
     subject { AbPanel.experiments }
 
-    it { should =~ %w(experiment1 experiment2).map(&:to_sym) }
+    it { is_expected.to match_array %w(experiment1 experiment2).map(&:to_sym) }
   end
 
   describe ".weights" do
     let(:experiment) { AbPanel.experiments.first }
     subject { AbPanel.weights(experiment) }
 
-    it { should == [25, 25, 25, 25] }
+    it { is_expected.to eq [25, 25, 25, 25] }
 
     describe "With a nonexistent experiment" do
       let(:experiment) { :does_not_exist }
@@ -27,7 +27,7 @@ describe AbPanel do
 
     let(:experiment) { AbPanel.experiments.first }
 
-    it { should =~ %w( scenario1 scenario2 scenario3 original ).map(&:to_sym) }
+    it { is_expected.to match_array %w( scenario1 scenario2 scenario3 original ).map(&:to_sym) }
 
     describe "With an nonexistent experiment" do
       let(:experiment) { :does_not_exist }
@@ -41,8 +41,8 @@ describe AbPanel do
   describe ".conditions" do
     subject { AbPanel.conditions.experiment1 }
 
-    it { should respond_to :scenario1? }
-    it { should respond_to :original? }
+    it { is_expected.to respond_to :scenario1? }
+    it { is_expected.to respond_to :original? }
 
     describe 'uniqueness' do
       let(:conditions) do
@@ -54,10 +54,10 @@ describe AbPanel do
         ]
       end
 
-      it { conditions.any?.should be true }
-      it { conditions.all?.should be false }
-      it { conditions.select{|c| c}.size.should be 1 }
-      it { conditions.reject{|c| c}.size.should be 3 }
+      it { expect(conditions.any?).to be true }
+      it { expect(conditions.all?).to be false }
+      it { expect(conditions.select{|c| c}.size).to be 1 }
+      it { expect(conditions.reject{|c| c}.size).to be 3 }
     end
   end
 
@@ -72,24 +72,24 @@ describe AbPanel do
 
     it 'adds a funnel' do
       AbPanel.add_funnel('search')
-      AbPanel.funnels.to_a.should == ['search']
+      expect(AbPanel.funnels.to_a).to eq ['search']
     end
 
     it 'only adds a funnel when present' do
       AbPanel.add_funnel(nil)
-      AbPanel.funnels.to_a.should == []
+      expect(AbPanel.funnels.to_a).to eq []
     end
 
     it 'does not add a funnel twice' do
       AbPanel.add_funnel('search')
       AbPanel.add_funnel('search')
-      AbPanel.funnels.to_a.should == ['search']
+      expect(AbPanel.funnels.to_a).to eq ['search']
     end
 
     it 'sets funnels' do
       funnels = Set.new ['search', 'cta']
       AbPanel.funnels = funnels
-      AbPanel.funnels.to_a.should == funnels.to_a
+      expect(AbPanel.funnels.to_a).to eq funnels.to_a
     end
   end
 

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -3,47 +3,47 @@ require 'spec_helper'
 describe Array do
   describe '.weighted_sample' do
     before do
-      Kernel.stub(:rand) { 0.5 }
+      allow(Kernel).to receive(:rand) { 0.5 }
     end
 
     context "Stub test" do
       subject { Kernel.rand }
-      it { should eq 0.5 }
+      it { is_expected.to eq 0.5 }
     end
 
     let(:array) { [1, 2, 3, 4] }
     subject { array.weighted_sample }
 
-    it { should eq 3 }
+    it { is_expected.to eq 3 }
 
     context "different random" do
       before do
-        Kernel.stub(:rand) { 0 }
+        allow(Kernel).to receive(:rand) { 0 }
       end
 
-      it { should eq 1 }
+      it { is_expected.to eq 1 }
     end
 
     context "different random" do
       before do
-        Kernel.stub(:rand) { 1 }
+        allow(Kernel).to receive(:rand) { 1 }
       end
 
-      it { should eq 4 }
+      it { is_expected.to eq 4 }
     end
 
     context "with weights" do
       subject { array.weighted_sample([1, 0, 0, 0]) }
-      it { should eq 1 }
+      it { is_expected.to eq 1 }
     end
-    
+
     context "all the same weights" do
-      before { Kernel.stub(:rand) { 1 } }
+      before { allow(Kernel).to receive(:rand) { 1 } }
       subject { array.weighted_sample([0, 0, 0, 0]) }
-      it { should eq 4 }
+      it { is_expected.to eq 4 }
       context "random 0" do
-        before { Kernel.stub(:rand) { 0 } }
-        it { should eq 1 }
+        before { allow(Kernel).to receive(:rand) { 0 } }
+        it { is_expected.to eq 1 }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,3 @@ require 'active_support/all'
 require File.join(File.dirname(__FILE__), "../lib", "ab_panel")
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
-

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -2,7 +2,7 @@ require 'rails'
 
 RSpec.configure do |c|
   c.before do
-    Rails.stub(:root) { File.expand_path( '../files', __FILE__ ) }
-    Rails.stub(:env) { 'test' }
+    allow(Rails).to receive(:root) { File.expand_path( '../files', __FILE__ ) }
+    allow(Rails).to receive(:env) { 'test' }
   end
 end


### PR DESCRIPTION
The serialization of an OpenStruct object has changed with Rails 4. Breaking
the ability to transparently getting the ab_panel_conditions cookie back as a
OpenStruct object. By manually serializing the ab_panel_conditions data in JSON
and doing some manual labor transforming the object back into OpenStruct this
issue has been resolved.