### PR TITLE
Only parse ab_panel_conditions cookie if it exists

### DIFF
--- a/lib/ab_panel/controller_additions.rb
+++ b/lib/ab_panel/controller_additions.rb
@@ -49,7 +49,13 @@ module AbPanel
     def initialize_ab_panel!(options = {})
       AbPanel.reset!
 
-      AbPanel.conditions = JSON.parse(cookies.signed[:ab_panel_conditions])
+
+      AbPanel.conditions =
+        if cookies.signed[:ab_panel_conditions]
+          JSON.parse(cookies.signed[:ab_panel_conditions])
+        else
+          nil
+        end
 
       cookies.signed[:ab_panel_conditions] = AbPanel.serialized_conditions
       AbPanel.funnels = Set.new(cookies.signed[:ab_panel_funnels])


### PR DESCRIPTION
This was causing issues when the cookie is not yet created.