### PR TITLE
Update gemspec to support rails 5

### DIFF
--- a/ab_panel.gemspec
+++ b/ab_panel.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
 
-  spec.add_runtime_dependency "rails", '~> 4.0'
+  spec.add_runtime_dependency "rails", '>= 4.0', '< 5.1'
   spec.add_runtime_dependency "mixpanel"
 end

--- a/ab_panel.gemspec
+++ b/ab_panel.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
 
-  spec.add_runtime_dependency "rails", '>= 4.0', '< 5.1'
+  spec.add_runtime_dependency "rails", '>= 4.0', '< 5.2'
   spec.add_runtime_dependency "mixpanel"
 end


### PR DESCRIPTION
Right now it's not supported. Specs pass, so not sure why wouldn't it support rails 5.0