### PR TITLE
Update cookie storage to httponly and secure

### DIFF
--- a/lib/ab_panel/controller_additions.rb
+++ b/lib/ab_panel/controller_additions.rb
@@ -27,8 +27,20 @@ module AbPanel
     #
     #   `current_user.id` for logged in users.
     def distinct_id
-      cookies.signed['distinct_id'] ||=
-        (0..4).map { |i| i.even? ? ('A'..'Z').to_a[rand(26)] : rand(10) }.join
+      distinct_id = cookies.signed['distinct_id']
+
+      return distinct_id if distinct_id
+
+      distinct_id = (0..4).map { |i| i.even? ? ('A'..'Z').to_a[rand(26)] : rand(10) }.join
+
+      cookies.signed['distinct_id'] =
+        {
+          value: distinct_id,
+          httponly: true,
+          secure: request.ssl?
+        }
+
+      distinct_id
     end
 
     def ab_panel_options
@@ -57,9 +69,18 @@ module AbPanel
           nil
         end
 
-      cookies.signed[:ab_panel_conditions] = AbPanel.serialized_conditions
+      cookies.signed[:ab_panel_conditions] = {
+        value: AbPanel.serialized_conditions,
+        httponly: true,
+        secure: request.ssl?
+      }
+
       AbPanel.funnels = Set.new(cookies.signed[:ab_panel_funnels])
-      cookies.signed[:ab_panel_funnels] = AbPanel.funnels
+      cookies.signed[:ab_panel_funnels] = {
+        value: AbPanel.funnels,
+        httponly: true,
+        secure: request.ssl?
+      }
 
       {
         'distinct_id' => distinct_id,

--- a/spec/ab_panel/controller_additions_spec.rb
+++ b/spec/ab_panel/controller_additions_spec.rb
@@ -13,7 +13,10 @@ describe AbPanel::ControllerAdditions do
 
   describe "#distinct_id" do
     let(:cookies) { {} }
-    before { expect(controller).to receive_message_chain(:cookies, :signed).and_return(cookies) }
+    before do
+      allow(controller).to receive_message_chain(:request, :ssl?).and_return(true)
+      allow(controller).to receive_message_chain(:cookies, :signed).and_return(cookies)
+    end
     subject { controller.distinct_id }
 
     it { is_expected.to match /^([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])([A-Z]|[0-9])$/ }


### PR DESCRIPTION
Enable httponly and secure (when `request.ssl?` is `true`) for cookies.