### PR TITLE
Remove ip address from default tracking

### DIFF
--- a/lib/ab_panel/controller_additions.rb
+++ b/lib/ab_panel/controller_additions.rb
@@ -88,7 +88,6 @@ module AbPanel
 
       options = {
         distinct_id: distinct_id,
-        ip:          request.remote_ip,
         time:        Time.now.utc,
       }.merge(properties)
 


### PR DESCRIPTION
This PR removes the sending along of IP address as part of the default data sent along to Mixpanel on tracking actions.