### PR TITLE
expose AbPanel::Javascript.environment as a hash so it can be used directly in json responses

### DIFF
--- a/lib/ab_panel.rb
+++ b/lib/ab_panel.rb
@@ -84,6 +84,17 @@ module AbPanel
       funnels.add(funnel) if funnel.present?
     end
 
+    def environment_hash
+      props = { distinct_id: self.env["distinct_id"] }
+      props.merge!(self.properties) if self.properties
+
+      self.funnels.each { |f| props["funnel_#{f}"] = true }
+
+      self.experiments.each { |exp| props[exp] = self.conditions.send(exp).condition }
+
+      props
+    end
+
     private # ----------------------------------------------------------------------------
 
     def assign_conditions!(already_assigned=nil)

--- a/lib/ab_panel.rb
+++ b/lib/ab_panel.rb
@@ -84,7 +84,7 @@ module AbPanel
       funnels.add(funnel) if funnel.present?
     end
 
-    def environment_hash
+    def environment
       props = { distinct_id: self.env["distinct_id"] }
       props.merge!(self.properties) if self.properties
 

--- a/lib/ab_panel/javascript.rb
+++ b/lib/ab_panel/javascript.rb
@@ -1,6 +1,10 @@
 module AbPanel
   class Javascript
     def self.environment
+      self.environment_hash.to_json
+    end
+
+    def self.environment_hash
       props = { distinct_id: AbPanel.env["distinct_id"] }
       props.merge!(AbPanel.properties) if AbPanel.properties
 
@@ -8,7 +12,7 @@ module AbPanel
 
       AbPanel.experiments.each { |exp| props[exp] = AbPanel.conditions.send(exp).condition }
 
-      props.to_json
+      props
     end
   end
 end

--- a/lib/ab_panel/javascript.rb
+++ b/lib/ab_panel/javascript.rb
@@ -1,18 +1,8 @@
 module AbPanel
   class Javascript
     def self.environment
-      self.environment_hash.to_json
+      AbPanel.environment.to_json
     end
 
-    def self.environment_hash
-      props = { distinct_id: AbPanel.env["distinct_id"] }
-      props.merge!(AbPanel.properties) if AbPanel.properties
-
-      AbPanel.funnels.each { |f| props["funnel_#{f}"] = true }
-
-      AbPanel.experiments.each { |exp| props[exp] = AbPanel.conditions.send(exp).condition }
-
-      props
-    end
   end
 end


### PR DESCRIPTION
We need to be able to use the `AbPanel::Javascript.environment` in a json response, therefor having the need to get the hash of the environment instead of the JSON-fied hash string.